### PR TITLE
ci: add Docker CI workflow for automated image builds on push to main

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -1,0 +1,32 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_IMAGE_NAME }}:latest


### PR DESCRIPTION
A new GitHub Actions workflow is introduced to automate the building and pushing of Docker images to DockerHub. This ensures that every push to the main branch triggers a CI process that builds multi-architecture images (linux/amd64 and linux/arm64) and pushes them with the latest tag, streamlining deployment and maintaining consistency across different platforms.